### PR TITLE
Event Schedule & Parade Route with Two-Track Layout

### DIFF
--- a/page-templates/template-event-day.php
+++ b/page-templates/template-event-day.php
@@ -69,6 +69,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                                 <span class="sub">Dance with colors</span>
                             </div>
                             <div class="parade-col">
+                                <strong>&nbsp;</strong><br>
                                 <span class="sub">Load up colors, head to Royal & Touro</span>
                             </div>
                         </div>
@@ -144,8 +145,13 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="NOLA Holi 2026 Parade Route Map">
                     </div>
                     
-                    <div class="route-text">
-                        <strong>Route:</strong> Royal & Touro → St Philip → Chartres → Kerlerec
+                    <div class="route-steps-compact">
+                        <p class="route-label">Route:</p>
+                        <p class="route-step">📍 Start at Royal & Touro</p>
+                        <p class="route-step">↓ to Esplanade</p>
+                        <p class="route-step">← Left on St Philip</p>
+                        <p class="route-step">← Left on Chartres</p>
+                        <p class="route-step">⬤ End at Chartres & Kerlerec</p>
                     </div>
                 </div>
                 

--- a/page-templates/template-event-day.php
+++ b/page-templates/template-event-day.php
@@ -68,7 +68,9 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                                 <strong>🎧 DJ Starts Spinning</strong><br>
                                 <span class="sub">Dance with colors</span>
                             </div>
-                            <div class="parade-col empty"></div>
+                            <div class="parade-col">
+                                <span class="sub">Load up colors, head to Royal & Touro</span>
+                            </div>
                         </div>
                         
                         <!-- 11:00 AM -->
@@ -79,18 +81,9 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                                 <span class="sub">Stay & splash colors</span>
                             </div>
                             <div class="parade-col">
-                                <strong>🎧 Parade DJ Starts Spinning</strong><br>
-                                <span class="sub">Dance with colors at Royal & Touro</span>
-                            </div>
-                        </div>
-                        
-                        <!-- 11:45 AM -->
-                        <div class="schedule-row">
-                            <div class="time-col">11:45 AM</div>
-                            <div class="park-col empty"></div>
-                            <div class="parade-col">
-                                <strong>📣 Parade Lineup</strong><br>
-                                <span class="sub">Load up your colors</span>
+                                <strong>🎧 Parade DJ Cranks Up</strong><br>
+                                <span class="sub">Pre-parade party with colors</span><br>
+                                <strong class="lineup-time">11:45 Parade Lineup</strong>
                             </div>
                         </div>
                         
@@ -98,8 +91,8 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row highlight">
                             <div class="time-col">12:00 PM</div>
                             <div class="park-col">
-                                <strong>🔊 DJ Ramps it Up</strong><br>
-                                <span class="sub">Continue the party</span>
+                                <strong>🔊 DJ Jams it Up</strong><br>
+                                <span class="sub">Party continues in the park</span>
                             </div>
                             <div class="parade-col">
                                 <strong>🎉 Parade Starts!</strong><br>
@@ -111,28 +104,20 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row reunite">
                             <div class="time-col">1:00 PM</div>
                             <div class="park-col">
-                                <strong>🎊 Everyone Reunites!</strong>
+                                <strong>🎊 Everyone Reunites!</strong><br>
+                                <span class="sub">Enjoy Cultural Performances</span>
                             </div>
                             <div class="parade-col">
-                                <span class="sub">Parade returns to Park</span>
+                                <strong class="parade-return">Parade Returns</strong>
                             </div>
-                        </div>
-                        
-                        <!-- 1:15 PM -->
-                        <div class="schedule-row">
-                            <div class="time-col">1:15 PM</div>
-                            <div class="park-col">
-                                <strong>🎭 Cultural Performances</strong>
-                            </div>
-                            <div class="parade-col empty"></div>
                         </div>
                         
                         <!-- 2:30 PM -->
                         <div class="schedule-row">
                             <div class="time-col">2:30 PM</div>
                             <div class="park-col">
-                                <strong>💃 Let's Dance!</strong><br>
-                                <span class="sub">DJ cranks it up</span>
+                                <strong>💃 DJ Cranks It Up</strong><br>
+                                <span class="sub">Dance your heart out</span>
                             </div>
                             <div class="parade-col empty"></div>
                         </div>
@@ -141,7 +126,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row last">
                             <div class="time-col">5:00 PM</div>
                             <div class="park-col">
-                                <strong>🎨 Event Ends</strong>
+                                <strong>🎨 See You Next Year!</strong>
                             </div>
                             <div class="parade-col empty"></div>
                         </div>

--- a/page-templates/template-event-day.php
+++ b/page-templates/template-event-day.php
@@ -59,6 +59,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                             <div class="card-time">10:00 AM</div>
                             <div class="card-details">
                                 <h3>Event Opens</h3>
+                                <p class="event-desc">DJ music, colors, food & drinks!</p>
                                 <p class="card-location">
                                     <span class="pin-icon"></span> Washington Square Park<br>
                                     <span class="address">700 Elysian Fields Ave</span>

--- a/page-templates/template-event-day.php
+++ b/page-templates/template-event-day.php
@@ -44,83 +44,111 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                 <p><?php echo esc_html($event_date); ?> • Washington Square Park</p>
             </div>
             
-            <div class="event-day-grid">
+            <div class="event-day-grid-new">
                 
-                <!-- Left Column: Schedule -->
-                <div class="event-schedule">
+                <!-- Left Column: Two-Track Schedule -->
+                <div class="event-schedule-dual">
                     <div class="schedule-header">
                         <span class="schedule-icon">🗓</span>
                         <h2>Event Schedule</h2>
                     </div>
                     
-                    <div class="schedule-cards">
+                    <div class="dual-schedule">
+                        <!-- Column Headers -->
+                        <div class="schedule-row header-row">
+                            <div class="time-col"></div>
+                            <div class="park-col"><span class="col-icon">🏞️</span> At the Park</div>
+                            <div class="parade-col"><span class="col-icon">🎭</span> Parade</div>
+                        </div>
                         
-                        <div class="schedule-card">
-                            <div class="card-time">10:00 AM</div>
-                            <div class="card-details">
-                                <h3>Event Opens</h3>
-                                <p class="event-desc">DJ music, colors, food & drinks!</p>
-                                <p class="card-location">
-                                    <span class="pin-icon"></span> Washington Square Park<br>
-                                    <span class="address">700 Elysian Fields Ave</span>
-                                </p>
+                        <!-- 10:00 AM -->
+                        <div class="schedule-row">
+                            <div class="time-col">10:00 AM</div>
+                            <div class="park-col">
+                                <strong>🎧 DJ Starts Spinning</strong><br>
+                                <span class="sub">Dance with colors</span>
+                            </div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <!-- 11:00 AM -->
+                        <div class="schedule-row">
+                            <div class="time-col">11:00 AM</div>
+                            <div class="park-col">
+                                <strong>🎵 DJ Keeps Spinning</strong><br>
+                                <span class="sub">Stay & splash colors</span>
+                            </div>
+                            <div class="parade-col">
+                                <strong>🎧 Parade DJ Starts Spinning</strong><br>
+                                <span class="sub">Dance with colors at Royal & Touro</span>
                             </div>
                         </div>
                         
-                        <div class="schedule-card">
-                            <div class="card-time">11:00 AM</div>
-                            <div class="card-details">
-                                <h3>Assemble for Parade</h3>
-                                <p class="card-location">
-                                    <span class="pin-icon"></span> Royal St at Touro Street<br>
-                                    <span class="address">1913 Royal St</span>
-                                </p>
+                        <!-- 11:45 AM -->
+                        <div class="schedule-row">
+                            <div class="time-col">11:45 AM</div>
+                            <div class="park-col empty"></div>
+                            <div class="parade-col">
+                                <strong>📣 Parade Lineup</strong><br>
+                                <span class="sub">Load up your colors</span>
                             </div>
                         </div>
                         
-                        <div class="schedule-card highlight">
-                            <div class="card-time">12:00 PM</div>
-                            <div class="card-details">
-                                <h3>🎉 Parade Starts!</h3>
+                        <!-- 12:00 PM -->
+                        <div class="schedule-row highlight">
+                            <div class="time-col">12:00 PM</div>
+                            <div class="park-col">
+                                <strong>🔊 DJ Ramps it Up</strong><br>
+                                <span class="sub">Continue the party</span>
+                            </div>
+                            <div class="parade-col">
+                                <strong>🎉 Parade Starts!</strong><br>
+                                <span class="sub">Color throw on the route!</span>
                             </div>
                         </div>
                         
-                        <div class="schedule-card">
-                            <div class="card-time">1:00 PM</div>
-                            <div class="card-details">
-                                <h3>Parade Returns</h3>
-                                <p>Back to Washington Square Park</p>
+                        <!-- 1:00 PM -->
+                        <div class="schedule-row reunite">
+                            <div class="time-col">1:00 PM</div>
+                            <div class="park-col">
+                                <strong>🎊 Everyone Reunites!</strong>
+                            </div>
+                            <div class="parade-col">
+                                <span class="sub">Parade returns to Park</span>
                             </div>
                         </div>
                         
-                        <div class="schedule-card">
-                            <div class="card-time">1:15 PM</div>
-                            <div class="card-details">
-                                <h3>Cultural Performances</h3>
-                                <p>Live music, dance & entertainment</p>
+                        <!-- 1:15 PM -->
+                        <div class="schedule-row">
+                            <div class="time-col">1:15 PM</div>
+                            <div class="park-col">
+                                <strong>🎭 Cultural Performances</strong>
                             </div>
+                            <div class="parade-col empty"></div>
                         </div>
                         
-                        <div class="schedule-card">
-                            <div class="card-time">2:30 PM</div>
-                            <div class="card-details">
-                                <h3>DJ Set</h3>
-                                <p>Dance party at the park!</p>
+                        <!-- 2:30 PM -->
+                        <div class="schedule-row">
+                            <div class="time-col">2:30 PM</div>
+                            <div class="park-col">
+                                <strong>💃 Let's Dance!</strong><br>
+                                <span class="sub">DJ cranks it up</span>
                             </div>
+                            <div class="parade-col empty"></div>
                         </div>
                         
-                        <div class="schedule-card last">
-                            <div class="card-time">5:00 PM</div>
-                            <div class="card-details">
-                                <h3>Event Ends</h3>
-                                <p>See you next year! 🎨</p>
+                        <!-- 5:00 PM -->
+                        <div class="schedule-row last">
+                            <div class="time-col">5:00 PM</div>
+                            <div class="park-col">
+                                <strong>🎨 Event Ends</strong>
                             </div>
+                            <div class="parade-col empty"></div>
                         </div>
-                        
                     </div>
                 </div>
                 
-                <!-- Middle Column: Parade Route Map -->
+                <!-- Right Column: Parade Route Map -->
                 <div class="parade-route-map">
                     <div class="route-header">
                         <span class="route-icon">🗺️</span>
@@ -130,44 +158,9 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                     <div class="route-map">
                         <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="NOLA Holi 2026 Parade Route Map">
                     </div>
-                </div>
-                
-                <!-- Right Column: Route Directions -->
-                <div class="parade-route-directions">
-                    <div class="route-header">
-                        <span class="route-icon">🧭</span>
-                        <h2>Parade Route</h2>
-                    </div>
                     
-                    <ol class="route-steps">
-                        <li>
-                            <span class="step-marker assemble"><span class="pin-icon"></span></span>
-                            <span class="step-text">Assemble at Royal St at Touro</span>
-                        </li>
-                        <li>
-                            <span class="step-marker start">START</span>
-                            <span class="step-text">Start down Royal St</span>
-                        </li>
-                        <li>
-                            <span class="step-marker turn">←</span>
-                            <span class="step-text">Left on St Philip</span>
-                        </li>
-                        <li>
-                            <span class="step-marker turn">←</span>
-                            <span class="step-text">Left on Chartres</span>
-                        </li>
-                        <li>
-                            <span class="step-marker straight">↑</span>
-                            <span class="step-text">Continue on Chartres</span>
-                        </li>
-                        <li>
-                            <span class="step-marker end">END</span>
-                            <span class="step-text">End at Chartres at Kerlerec</span>
-                        </li>
-                    </ol>
-                    
-                    <div class="route-note">
-                        <p>💡 <strong>Tip:</strong> Arrive at the parade assembly point by 11:00 AM to join the march!</p>
+                    <div class="route-text">
+                        <strong>Route:</strong> Royal & Touro → St Philip → Chartres → Kerlerec
                     </div>
                 </div>
                 

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -171,13 +171,8 @@
         }
         
         /* Instagram specific adjustments */
-        .instagram-page .vendors-header h3 {
-            font-size: 1.2rem;
-        }
-        
-        .instagram-page .vendor-logo-new {
-            height: 55px;
-            max-width: 140px;
+        .instagram-page .vendors-names {
+            font-size: 1.1rem;
         }
         
         .instagram-page .social-info-bar {
@@ -348,21 +343,15 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
     </section>
     
     <!-- Food Vendors Section -->
-    <section class="social-vendors-new">
-        <div class="vendors-header">
-            <h3>Authentic Indian Cuisine</h3>
-        </div>
-        <div class="vendors-grid">
-            <div class="vendor-item">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-new">
-            </div>
-            <div class="vendor-item">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-new">
-            </div>
-            <div class="vendor-item">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-new">
-            </div>
-        </div>
+    <section class="social-vendors-text">
+        <p class="vendors-title">Authentic Indian Cuisine by</p>
+        <p class="vendors-names">
+            <span>Indian Delight</span>
+            <span class="separator">•</span>
+            <span>Aroma Indian Cuisine</span>
+            <span class="separator">•</span>
+            <span>Destination India</span>
+        </p>
     </section>
     
     <!-- Info Bar -->

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * Template Name: Social Share - Instagram
+ * A page optimized for Instagram screenshots with crop guides
+ * Shows boundary lines for 1:1 (square) and 4:5 (portrait) aspect ratios
+ * 
+ * @package NOLAHoli
+ */
+
+// Minimal HTML head without site header
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+    <style>
+        /* Instagram-specific overrides */
+        .instagram-container {
+            position: relative;
+            width: 1080px;
+            margin: 0 auto;
+            background: var(--white);
+        }
+        
+        /* Crop guide overlays - toggle with checkboxes */
+        .crop-guides {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background: rgba(0, 0, 0, 0.8);
+            padding: 15px;
+            border-radius: 8px;
+            z-index: 1000;
+            color: white;
+            font-family: system-ui, sans-serif;
+        }
+        
+        .crop-guides label {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin: 5px 0;
+            cursor: pointer;
+        }
+        
+        .crop-guides .guide-info {
+            font-size: 11px;
+            color: #aaa;
+            margin-left: 24px;
+        }
+        
+        /* Square guide (1:1 - 1080x1080) */
+        .guide-square {
+            position: fixed;
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 1080px;
+            height: 1080px;
+            border: 3px dashed #00ff00;
+            pointer-events: none;
+            z-index: 999;
+            display: none;
+        }
+        
+        .guide-square::before {
+            content: "1:1 Square (1080×1080)";
+            position: absolute;
+            top: -25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #00ff00;
+            color: black;
+            padding: 2px 10px;
+            font-size: 12px;
+            font-weight: bold;
+            border-radius: 4px;
+        }
+        
+        /* Portrait guide (4:5 - 1080x1350) */
+        .guide-portrait {
+            position: fixed;
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 1080px;
+            height: 1350px;
+            border: 3px dashed #ff00ff;
+            pointer-events: none;
+            z-index: 998;
+            display: none;
+        }
+        
+        .guide-portrait::before {
+            content: "4:5 Portrait (1080×1350)";
+            position: absolute;
+            top: -25px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #ff00ff;
+            color: white;
+            padding: 2px 10px;
+            font-size: 12px;
+            font-weight: bold;
+            border-radius: 4px;
+        }
+        
+        #toggle-square:checked ~ .guide-square {
+            display: block;
+        }
+        
+        #toggle-portrait:checked ~ .guide-portrait {
+            display: block;
+        }
+        
+        /* Instagram optimized layout - more compact */
+        .insta-hero {
+            min-height: 200px;
+            padding: 30px 20px;
+        }
+        
+        .insta-hero .sponsor-name {
+            font-size: 1.6rem;
+            margin-bottom: 5px;
+        }
+        
+        .insta-hero .hero-title-large {
+            font-size: 2.8rem;
+        }
+        
+        .insta-hero .hero-event-info {
+            font-size: 1.2rem;
+            margin-top: 10px;
+        }
+        
+        .insta-details-section {
+            padding: 12px 15px 15px;
+        }
+        
+        .insta-details-section .social-section-title {
+            font-size: 1.5rem;
+            margin-bottom: 12px;
+            padding-bottom: 6px;
+        }
+        
+        .insta-details-section .social-column-header h3 {
+            font-size: 1rem;
+        }
+        
+        .insta-details-section .schedule-item .time,
+        .insta-details-section .schedule-item .activity {
+            font-size: 0.9rem;
+        }
+        
+        .insta-details-section .route-text {
+            font-size: 0.9rem;
+        }
+        
+        .insta-footer {
+            padding: 12px 15px;
+        }
+        
+        .insta-footer .website-url {
+            font-size: 1.5rem;
+        }
+        
+        .insta-footer .tagline {
+            font-size: 0.9rem;
+        }
+        
+        /* Hide guides panel when taking screenshot */
+        @media print {
+            .crop-guides,
+            .guide-square,
+            .guide-portrait {
+                display: none !important;
+            }
+        }
+    </style>
+</head>
+<body <?php body_class('social-share-page instagram-page'); ?>>
+
+<!-- Crop Guide Controls -->
+<div class="crop-guides">
+    <strong>📐 Crop Guides</strong>
+    <label>
+        <input type="checkbox" id="toggle-square-ctrl" onchange="document.getElementById('guide-square').style.display = this.checked ? 'block' : 'none'">
+        <span style="color: #00ff00;">■</span> Square (1:1)
+    </label>
+    <div class="guide-info">Best for feed posts</div>
+    <label>
+        <input type="checkbox" id="toggle-portrait-ctrl" onchange="document.getElementById('guide-portrait').style.display = this.checked ? 'block' : 'none'">
+        <span style="color: #ff00ff;">■</span> Portrait (4:5)
+    </label>
+    <div class="guide-info">More visible in feed</div>
+    <hr style="border-color: #444; margin: 10px 0;">
+    <small>Hide this panel before screenshot</small>
+</div>
+
+<!-- Crop Guide Overlays -->
+<div class="guide-square" id="guide-square"></div>
+<div class="guide-portrait" id="guide-portrait"></div>
+
+<?php
+// Get event info from theme customizer
+$event_date = get_theme_mod('nolaholi_event_date', 'March 8, 2026');
+$event_time = get_theme_mod('nolaholi_event_time', '10:00am - 5:00pm');
+$event_year = $event_date ? date('Y', strtotime($event_date)) : date('Y');
+
+// Get presenting sponsor from database
+$presenting_sponsor = nolaholi_get_first_event_sponsor();
+$sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
+?>
+
+<div class="instagram-container">
+<main id="primary" class="site-main social-share-page">
+    <!-- Hero Section - Aurora/Holi Style -->
+    <section class="hero-section event-day-hero social-hero insta-hero">
+        <div class="hero-overlay"></div>
+        <div class="hero-content">
+            <?php if ($sponsor_name) : ?>
+            <p class="presented-by">Presented by</p>
+            <h2 class="sponsor-name"><?php echo esc_html($sponsor_name); ?></h2>
+            <?php endif; ?>
+            <h1 class="hero-title-large"><span class="cursive-text">NOLA Holi Festival <?php echo esc_html($event_year); ?></span></h1>
+            <p class="hero-event-info"><?php echo esc_html($event_date); ?> @ Washington Square Park</p>
+        </div>
+    </section>
+    
+    <!-- Event Details Section -->
+    <section class="social-details-section insta-details-section">
+        <h2 class="social-section-title">Event Details</h2>
+        
+        <div class="social-three-columns">
+            
+            <!-- Schedule Column -->
+            <div class="social-column">
+                <div class="social-column-header schedule-header-bg">
+                    <span class="column-icon">🗓</span>
+                    <h3>Schedule</h3>
+                </div>
+                <div class="social-column-content">
+                    <div class="schedule-item">
+                        <span class="time">10:00 AM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">Event Opens</span>
+                    </div>
+                    <div class="schedule-item highlight">
+                        <span class="time">11:00 AM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">Parade Assembly</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">12:00 PM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">🎉 Parade Starts!</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">1:00 PM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">Parade Returns</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">1:15 PM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">Performances</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">2:30 PM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">DJ Set</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">5:00 PM</span>
+                        <span class="dotted-line"></span>
+                        <span class="activity">Event Ends</span>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Parade Map Column -->
+            <div class="social-column">
+                <div class="social-column-header map-header-bg">
+                    <span class="column-icon">🗺️</span>
+                    <h3>Parade Map</h3>
+                </div>
+                <div class="social-column-content map-content">
+                    <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="Parade Route Map" class="social-map-image">
+                </div>
+            </div>
+            
+            <!-- Parade Route Column -->
+            <div class="social-column">
+                <div class="social-column-header route-header-bg">
+                    <span class="column-icon">🧭</span>
+                    <h3>Parade Route</h3>
+                </div>
+                <div class="social-column-content">
+                    <div class="route-item highlight">
+                        <span class="route-marker assemble">📍</span>
+                        <span class="route-text">Assemble at Royal & Touro</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker start">▶</span>
+                        <span class="route-text">Start down Royal St</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker turn">←</span>
+                        <span class="route-text">Left on St Philip</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker turn">←</span>
+                        <span class="route-text">Left on Chartres</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker straight">↓</span>
+                        <span class="route-text">Continue on Chartres</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker end">⬤</span>
+                        <span class="route-text">End at Chartres & Kerlerec</span>
+                    </div>
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+    <!-- Footer with Website -->
+    <section class="social-footer insta-footer">
+        <p class="website-url">NOLAHoli.org</p>
+        <p class="tagline">Free Admission • Family Friendly • All Are Welcome</p>
+    </section>
+</main>
+</div>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -170,6 +170,41 @@
             font-size: 0.9rem;
         }
         
+        /* Food Vendors Section */
+        .insta-vendors-section {
+            background: #f8f8f8;
+            padding: 15px 20px;
+            text-align: center;
+        }
+        
+        .vendors-label {
+            font-size: 0.85rem;
+            color: #666;
+            margin: 0 0 10px 0;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        
+        .vendors-logos {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 30px;
+        }
+        
+        .vendor-logo-small {
+            height: 50px;
+            width: auto;
+            max-width: 120px;
+            object-fit: contain;
+            filter: grayscale(0%);
+            transition: transform 0.2s ease;
+        }
+        
+        .vendor-logo-small:hover {
+            transform: scale(1.05);
+        }
+        
         /* Hide guides panel when taking screenshot */
         @media print {
             .crop-guides,
@@ -332,6 +367,22 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
     <section class="social-footer insta-footer">
         <p class="website-url">NOLAHoli.org</p>
         <p class="tagline">Free Admission • Family Friendly • All Are Welcome</p>
+    </section>
+    
+    <!-- Food Vendors - Logos Only -->
+    <section class="insta-vendors-section">
+        <p class="vendors-label">Food Vendors</p>
+        <div class="vendors-logos">
+            <a href="https://www.indiandelightms.com/" target="_blank" rel="noopener noreferrer">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-small">
+            </a>
+            <a href="https://aromanolaindiancuisine.com/" target="_blank" rel="noopener noreferrer">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-small">
+            </a>
+            <a href="https://destinationindiala.com/" target="_blank" rel="noopener noreferrer">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-small">
+            </a>
+        </div>
     </section>
 </main>
 </div>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -170,18 +170,26 @@
             font-size: 0.9rem;
         }
         
-        /* Instagram footer grid adjustments */
-        .instagram-page .social-footer-grid {
-            padding: 12px 15px;
+        /* Instagram specific adjustments */
+        .instagram-page .vendors-header h3 {
+            font-size: 1.2rem;
         }
         
-        .instagram-page .footer-col-title {
-            font-size: 1.3rem;
+        .instagram-page .vendor-logo-new {
+            height: 40px;
         }
         
-        .instagram-page .footer-vendor-logo {
-            height: 35px;
-            max-width: 70px;
+        .instagram-page .vendor-name {
+            font-size: 0.8rem;
+        }
+        
+        .instagram-page .social-info-bar {
+            font-size: 1rem;
+            padding: 8px 15px;
+        }
+        
+        .instagram-page .social-dark-strip {
+            padding: 10px 15px;
         }
         
         /* Hide guides panel when taking screenshot */
@@ -342,24 +350,39 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         </div>
     </section>
     
-    <!-- Footer - Three Column Layout -->
-    <section class="social-footer-grid">
-        <div class="footer-col">
-            <p class="footer-col-title">NOLAHoli.org</p>
-            <p class="footer-col-subtitle">Free Admission</p>
+    <!-- Food Vendors Section -->
+    <section class="social-vendors-new">
+        <div class="vendors-header">
+            <h3>Authentic Indian Cuisine</h3>
         </div>
-        <div class="footer-col">
-            <p class="footer-col-label">Food Vendors</p>
-            <div class="footer-vendor-logos">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="footer-vendor-logo">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="footer-vendor-logo">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="footer-vendor-logo">
+        <div class="vendors-grid">
+            <div class="vendor-item">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-new">
+                <p class="vendor-name">Indian Delight, MS</p>
+            </div>
+            <div class="vendor-item">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-new">
+                <p class="vendor-name">Aroma, NOLA</p>
+            </div>
+            <div class="vendor-item">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-new">
+                <p class="vendor-name">Destination India, Lafayette</p>
             </div>
         </div>
-        <div class="footer-col">
-            <p class="footer-col-tagline">Family Friendly</p>
-            <p class="footer-col-tagline">All Are Welcome</p>
-        </div>
+    </section>
+    
+    <!-- Info Bar -->
+    <section class="social-info-bar">
+        <span>Free Entrance</span>
+        <span class="bullet">•</span>
+        <span>Family Friendly</span>
+        <span class="bullet">•</span>
+        <span>All Are Welcome</span>
+    </section>
+    
+    <!-- Dark Footer Strip -->
+    <section class="social-dark-strip">
+        <p>Visit: <strong>NOLAHoli.org</strong></p>
     </section>
 </main>
 </div>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -170,39 +170,18 @@
             font-size: 0.9rem;
         }
         
-        /* Food Vendors Section */
-        .insta-vendors-section {
-            background: #f8f8f8;
-            padding: 15px 20px;
-            text-align: center;
+        /* Instagram footer grid adjustments */
+        .instagram-page .social-footer-grid {
+            padding: 12px 15px;
         }
         
-        .vendors-label {
-            font-size: 0.85rem;
-            color: #666;
-            margin: 0 0 10px 0;
-            text-transform: uppercase;
-            letter-spacing: 1px;
+        .instagram-page .footer-col-title {
+            font-size: 1.3rem;
         }
         
-        .vendors-logos {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: 30px;
-        }
-        
-        .vendor-logo-small {
-            height: 50px;
-            width: auto;
-            max-width: 120px;
-            object-fit: contain;
-            filter: grayscale(0%);
-            transition: transform 0.2s ease;
-        }
-        
-        .vendor-logo-small:hover {
-            transform: scale(1.05);
+        .instagram-page .footer-vendor-logo {
+            height: 35px;
+            max-width: 70px;
         }
         
         /* Hide guides panel when taking screenshot */
@@ -363,25 +342,23 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         </div>
     </section>
     
-    <!-- Footer with Website -->
-    <section class="social-footer insta-footer">
-        <p class="website-url">NOLAHoli.org</p>
-        <p class="tagline">Free Admission • Family Friendly • All Are Welcome</p>
-    </section>
-    
-    <!-- Food Vendors - Logos Only -->
-    <section class="insta-vendors-section">
-        <p class="vendors-label">Food Vendors</p>
-        <div class="vendors-logos">
-            <a href="https://www.indiandelightms.com/" target="_blank" rel="noopener noreferrer">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-small">
-            </a>
-            <a href="https://aromanolaindiancuisine.com/" target="_blank" rel="noopener noreferrer">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-small">
-            </a>
-            <a href="https://destinationindiala.com/" target="_blank" rel="noopener noreferrer">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-small">
-            </a>
+    <!-- Footer - Three Column Layout -->
+    <section class="social-footer-grid">
+        <div class="footer-col">
+            <p class="footer-col-title">NOLAHoli.org</p>
+            <p class="footer-col-subtitle">Free Admission</p>
+        </div>
+        <div class="footer-col">
+            <p class="footer-col-label">Food Vendors</p>
+            <div class="footer-vendor-logos">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="footer-vendor-logo">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="footer-vendor-logo">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="footer-vendor-logo">
+            </div>
+        </div>
+        <div class="footer-col">
+            <p class="footer-col-tagline">Family Friendly</p>
+            <p class="footer-col-tagline">All Are Welcome</p>
         </div>
     </section>
 </main>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -176,11 +176,8 @@
         }
         
         .instagram-page .vendor-logo-new {
-            height: 40px;
-        }
-        
-        .instagram-page .vendor-name {
-            font-size: 0.8rem;
+            height: 55px;
+            max-width: 140px;
         }
         
         .instagram-page .social-info-bar {
@@ -358,15 +355,12 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         <div class="vendors-grid">
             <div class="vendor-item">
                 <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-new">
-                <p class="vendor-name">Indian Delight, MS</p>
             </div>
             <div class="vendor-item">
                 <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-new">
-                <p class="vendor-name">Aroma, NOLA</p>
             </div>
             <div class="vendor-item">
                 <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-new">
-                <p class="vendor-name">Destination India, Lafayette</p>
             </div>
         </div>
     </section>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -323,7 +323,14 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                 </div>
                 <div class="social-column-content map-content">
                     <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="Parade Route Map" class="social-map-image">
-                    <p class="route-text-inline"><strong>Route:</strong> Royal & Touro → St Philip → Chartres → Kerlerec</p>
+                    <div class="route-steps-compact">
+                        <p class="route-label">Route:</p>
+                        <p class="route-step">📍 Start at Royal & Touro</p>
+                        <p class="route-step">↓ to Esplanade</p>
+                        <p class="route-step">← Left on St Philip</p>
+                        <p class="route-step">← Left on Chartres</p>
+                        <p class="route-step">⬤ End at Chartres & Kerlerec</p>
+                    </div>
                 </div>
             </div>
             

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -260,6 +260,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <span class="time">10:00 AM</span>
                         <span class="dotted-line"></span>
                         <span class="activity">Event Opens</span>
+                        <span class="event-subtext">DJ music, colors, food & drinks!</span>
                     </div>
                     <div class="schedule-item highlight">
                         <span class="time">11:00 AM</span>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -267,7 +267,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row-social">
                             <div class="time-col">10:00</div>
                             <div class="park-col"><strong>🎧 DJ Starts Spinning</strong><br><span class="sub">Dance with colors</span></div>
-                            <div class="parade-col"><span class="sub">Load up colors, head to Royal & Touro</span></div>
+                            <div class="parade-col"><strong>&nbsp;</strong><br><span class="sub">Load up colors, head to Royal & Touro</span></div>
                         </div>
                         
                         <div class="schedule-row-social">

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -267,48 +267,36 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row-social">
                             <div class="time-col">10:00</div>
                             <div class="park-col"><strong>🎧 DJ Starts Spinning</strong><br><span class="sub">Dance with colors</span></div>
-                            <div class="parade-col empty"></div>
+                            <div class="parade-col"><span class="sub">Load up colors, head to Royal & Touro</span></div>
                         </div>
                         
                         <div class="schedule-row-social">
                             <div class="time-col">11:00</div>
                             <div class="park-col"><strong>🎵 DJ Keeps Spinning</strong><br><span class="sub">Stay & splash colors</span></div>
-                            <div class="parade-col"><strong>🎧 Parade DJ Spinning</strong><br><span class="sub">Colors at Royal & Touro</span></div>
-                        </div>
-                        
-                        <div class="schedule-row-social">
-                            <div class="time-col">11:45</div>
-                            <div class="park-col empty"></div>
-                            <div class="parade-col"><strong>📣 Parade Lineup</strong><br><span class="sub">Load up your colors</span></div>
+                            <div class="parade-col"><strong>🎧 Parade DJ Cranks Up</strong><br><span class="sub">Pre-parade party with colors</span><br><strong class="lineup-time">11:45 Parade Lineup</strong></div>
                         </div>
                         
                         <div class="schedule-row-social highlight">
                             <div class="time-col">12:00</div>
-                            <div class="park-col"><strong>🔊 DJ Ramps it Up</strong><br><span class="sub">Continue the party</span></div>
+                            <div class="park-col"><strong>🔊 DJ Jams it Up</strong><br><span class="sub">Party continues in the park</span></div>
                             <div class="parade-col"><strong>🎉 Parade Starts!</strong><br><span class="sub">Color throw on route!</span></div>
                         </div>
                         
                         <div class="schedule-row-social reunite">
                             <div class="time-col">1:00</div>
-                            <div class="park-col"><strong>🎊 Everyone Reunites!</strong></div>
-                            <div class="parade-col"><span class="sub">Parade returns</span></div>
-                        </div>
-                        
-                        <div class="schedule-row-social">
-                            <div class="time-col">1:15</div>
-                            <div class="park-col"><strong>🎭 Cultural Performances</strong></div>
-                            <div class="parade-col empty"></div>
+                            <div class="park-col"><strong>🎊 Everyone Reunites!</strong><br><span class="sub">Enjoy Cultural Performances</span></div>
+                            <div class="parade-col"><strong class="parade-return">Parade Returns</strong></div>
                         </div>
                         
                         <div class="schedule-row-social">
                             <div class="time-col">2:30</div>
-                            <div class="park-col"><strong>💃 Let's Dance!</strong><br><span class="sub">DJ cranks it up</span></div>
+                            <div class="park-col"><strong>💃 DJ Cranks It Up</strong><br><span class="sub">Dance your heart out</span></div>
                             <div class="parade-col empty"></div>
                         </div>
                         
                         <div class="schedule-row-social">
                             <div class="time-col">5:00</div>
-                            <div class="park-col"><strong>🎨 Event Ends</strong></div>
+                            <div class="park-col"><strong>🎨 See You Next Year!</strong></div>
                             <div class="parade-col empty"></div>
                         </div>
                     </div>

--- a/page-templates/template-social-instagram.php
+++ b/page-templates/template-social-instagram.php
@@ -247,50 +247,70 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
     <section class="social-details-section insta-details-section">
         <h2 class="social-section-title">Event Details</h2>
         
-        <div class="social-three-columns">
+        <div class="social-two-columns">
             
-            <!-- Schedule Column -->
-            <div class="social-column">
+            <!-- Schedule Column (Two-Track) -->
+            <div class="social-column wide">
                 <div class="social-column-header schedule-header-bg">
                     <span class="column-icon">🗓</span>
                     <h3>Schedule</h3>
                 </div>
                 <div class="social-column-content">
-                    <div class="schedule-item">
-                        <span class="time">10:00 AM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Event Opens</span>
-                        <span class="event-subtext">DJ music, colors, food & drinks!</span>
-                    </div>
-                    <div class="schedule-item highlight">
-                        <span class="time">11:00 AM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Parade Assembly</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">12:00 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">🎉 Parade Starts!</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">1:00 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Parade Returns</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">1:15 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Performances</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">2:30 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">DJ Set</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">5:00 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Event Ends</span>
+                    <div class="dual-schedule-social">
+                        <!-- Column Headers -->
+                        <div class="schedule-row-social header-row">
+                            <div class="time-col"></div>
+                            <div class="park-col">🏞️ At the Park</div>
+                            <div class="parade-col">🎭 Parade</div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">10:00</div>
+                            <div class="park-col"><strong>🎧 DJ Starts Spinning</strong><br><span class="sub">Dance with colors</span></div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">11:00</div>
+                            <div class="park-col"><strong>🎵 DJ Keeps Spinning</strong><br><span class="sub">Stay & splash colors</span></div>
+                            <div class="parade-col"><strong>🎧 Parade DJ Spinning</strong><br><span class="sub">Colors at Royal & Touro</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">11:45</div>
+                            <div class="park-col empty"></div>
+                            <div class="parade-col"><strong>📣 Parade Lineup</strong><br><span class="sub">Load up your colors</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social highlight">
+                            <div class="time-col">12:00</div>
+                            <div class="park-col"><strong>🔊 DJ Ramps it Up</strong><br><span class="sub">Continue the party</span></div>
+                            <div class="parade-col"><strong>🎉 Parade Starts!</strong><br><span class="sub">Color throw on route!</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social reunite">
+                            <div class="time-col">1:00</div>
+                            <div class="park-col"><strong>🎊 Everyone Reunites!</strong></div>
+                            <div class="parade-col"><span class="sub">Parade returns</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">1:15</div>
+                            <div class="park-col"><strong>🎭 Cultural Performances</strong></div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">2:30</div>
+                            <div class="park-col"><strong>💃 Let's Dance!</strong><br><span class="sub">DJ cranks it up</span></div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">5:00</div>
+                            <div class="park-col"><strong>🎨 Event Ends</strong></div>
+                            <div class="parade-col empty"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -303,40 +323,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                 </div>
                 <div class="social-column-content map-content">
                     <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="Parade Route Map" class="social-map-image">
-                </div>
-            </div>
-            
-            <!-- Parade Route Column -->
-            <div class="social-column">
-                <div class="social-column-header route-header-bg">
-                    <span class="column-icon">🧭</span>
-                    <h3>Parade Route</h3>
-                </div>
-                <div class="social-column-content">
-                    <div class="route-item highlight">
-                        <span class="route-marker assemble">📍</span>
-                        <span class="route-text">Assemble at Royal & Touro</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker start">▶</span>
-                        <span class="route-text">Start down Royal St</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker turn">←</span>
-                        <span class="route-text">Left on St Philip</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker turn">←</span>
-                        <span class="route-text">Left on Chartres</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker straight">↓</span>
-                        <span class="route-text">Continue on Chartres</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker end">⬤</span>
-                        <span class="route-text">End at Chartres & Kerlerec</span>
-                    </div>
+                    <p class="route-text-inline"><strong>Route:</strong> Royal & Touro → St Philip → Chartres → Kerlerec</p>
                 </div>
             </div>
             

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Template Name: Social Share
+ * A page optimized for social media screenshots
+ * 
+ * @package NOLAHoli
+ */
+
+get_header();
+
+// Get event info from theme customizer
+$event_date = get_theme_mod('nolaholi_event_date', 'March 8, 2026');
+$event_time = get_theme_mod('nolaholi_event_time', '10:00am - 5:00pm');
+$event_year = $event_date ? date('Y', strtotime($event_date)) : date('Y');
+
+// Get presenting sponsor from database
+$presenting_sponsor = nolaholi_get_first_event_sponsor();
+$sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
+?>
+
+<main id="primary" class="site-main social-share-page">
+    <!-- Hero Section - Aurora/Holi Style -->
+    <section class="hero-section event-day-hero social-hero">
+        <div class="hero-overlay"></div>
+        <div class="hero-content">
+            <?php if ($sponsor_name) : ?>
+            <p class="presented-by">Presented by</p>
+            <h2 class="sponsor-name"><?php echo esc_html($sponsor_name); ?></h2>
+            <?php endif; ?>
+            <p class="hero-tagline">The Biggest</p>
+            <h1 class="hero-title-large"><span class="cursive-text">Festival of Colors</span></h1>
+            <div class="gold-ribbon">
+                <span>IN NEW ORLEANS</span>
+            </div>
+        </div>
+    </section>
+    
+    <!-- Event Title Section -->
+    <section class="social-event-title">
+        <h1 class="nola-holi-title">NOLA Holi Festival <?php echo esc_html($event_year); ?></h1>
+        <div class="event-datetime">
+            <span class="event-date-large"><?php echo esc_html($event_date); ?></span>
+            <span class="event-time-large"><?php echo esc_html($event_time); ?></span>
+        </div>
+        <p class="event-location-large">Washington Square Park, New Orleans</p>
+    </section>
+    
+    <!-- Event Details Section -->
+    <section class="social-details-section">
+        <h2 class="social-section-title">Event Details</h2>
+        
+        <div class="social-three-columns">
+            
+            <!-- Schedule Column -->
+            <div class="social-column">
+                <div class="social-column-header schedule-header-bg">
+                    <span class="column-icon">🗓</span>
+                    <h3>Schedule</h3>
+                </div>
+                <div class="social-column-content">
+                    <div class="schedule-item">
+                        <span class="time">10:00 AM</span>
+                        <span class="activity">Event Opens</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">11:00 AM</span>
+                        <span class="activity">Parade Assembly</span>
+                    </div>
+                    <div class="schedule-item highlight">
+                        <span class="time">12:00 PM</span>
+                        <span class="activity">🎉 Parade Starts!</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">1:00 PM</span>
+                        <span class="activity">Parade Returns</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">1:15 PM</span>
+                        <span class="activity">Performances</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">2:30 PM</span>
+                        <span class="activity">DJ Set</span>
+                    </div>
+                    <div class="schedule-item">
+                        <span class="time">5:00 PM</span>
+                        <span class="activity">Event Ends</span>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Parade Map Column -->
+            <div class="social-column">
+                <div class="social-column-header map-header-bg">
+                    <span class="column-icon">🗺️</span>
+                    <h3>Parade Map</h3>
+                </div>
+                <div class="social-column-content map-content">
+                    <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="Parade Route Map" class="social-map-image">
+                </div>
+            </div>
+            
+            <!-- Parade Route Column -->
+            <div class="social-column">
+                <div class="social-column-header route-header-bg">
+                    <span class="column-icon">🧭</span>
+                    <h3>Parade Route</h3>
+                </div>
+                <div class="social-column-content">
+                    <div class="route-item">
+                        <span class="route-marker assemble">📍</span>
+                        <span class="route-text">Assemble at Royal & Touro</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker start">▶</span>
+                        <span class="route-text">Start down Royal St</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker turn">←</span>
+                        <span class="route-text">Left on St Philip</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker turn">←</span>
+                        <span class="route-text">Left on Chartres</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker straight">↑</span>
+                        <span class="route-text">Continue on Chartres</span>
+                    </div>
+                    <div class="route-item">
+                        <span class="route-marker end">⬤</span>
+                        <span class="route-text">End at Chartres & Kerlerec</span>
+                    </div>
+                    <div class="route-note-social">
+                        <strong>💡 Tip:</strong> Arrive by 11 AM to join the parade!
+                    </div>
+                </div>
+            </div>
+            
+        </div>
+    </section>
+    
+    <!-- Footer with Website -->
+    <section class="social-footer">
+        <p class="website-url">NOLAHoli.org</p>
+        <p class="tagline">Free Admission • Family Friendly • All Are Welcome</p>
+    </section>
+</main>
+
+<?php
+get_footer();
+?>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -1,13 +1,23 @@
 <?php
 /**
  * Template Name: Social Share
- * A page optimized for social media screenshots
+ * A page optimized for social media screenshots (no header/footer for clean screenshots)
  * 
  * @package NOLAHoli
  */
 
-get_header();
+// Minimal HTML head without site header
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class('social-share-page'); ?>>
 
+<?php
 // Get event info from theme customizer
 $event_date = get_theme_mod('nolaholi_event_date', 'March 8, 2026');
 $event_time = get_theme_mod('nolaholi_event_time', '10:00am - 5:00pm');
@@ -47,30 +57,37 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                 <div class="social-column-content">
                     <div class="schedule-item">
                         <span class="time">10:00 AM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">Event Opens</span>
                     </div>
-                    <div class="schedule-item">
+                    <div class="schedule-item highlight">
                         <span class="time">11:00 AM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">Parade Assembly</span>
                     </div>
-                    <div class="schedule-item highlight">
+                    <div class="schedule-item">
                         <span class="time">12:00 PM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">🎉 Parade Starts!</span>
                     </div>
                     <div class="schedule-item">
                         <span class="time">1:00 PM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">Parade Returns</span>
                     </div>
                     <div class="schedule-item">
                         <span class="time">1:15 PM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">Performances</span>
                     </div>
                     <div class="schedule-item">
                         <span class="time">2:30 PM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">DJ Set</span>
                     </div>
                     <div class="schedule-item">
                         <span class="time">5:00 PM</span>
+                        <span class="dotted-line"></span>
                         <span class="activity">Event Ends</span>
                     </div>
                 </div>
@@ -111,15 +128,12 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <span class="route-text">Left on Chartres</span>
                     </div>
                     <div class="route-item">
-                        <span class="route-marker straight">↑</span>
+                        <span class="route-marker straight">↓</span>
                         <span class="route-text">Continue on Chartres</span>
                     </div>
                     <div class="route-item">
                         <span class="route-marker end">⬤</span>
                         <span class="route-text">End at Chartres & Kerlerec</span>
-                    </div>
-                    <div class="route-note-social">
-                        <strong>💡 Tip:</strong> Arrive by 11 AM to join the parade!
                     </div>
                 </div>
             </div>
@@ -134,6 +148,6 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
     </section>
 </main>
 
-<?php
-get_footer();
-?>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -146,6 +146,22 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         <p class="website-url">NOLAHoli.org</p>
         <p class="tagline">Free Admission • Family Friendly • All Are Welcome</p>
     </section>
+    
+    <!-- Food Vendors - Logos Only -->
+    <section class="social-vendors-section">
+        <p class="vendors-label">Food Vendors</p>
+        <div class="vendors-logos">
+            <a href="https://www.indiandelightms.com/" target="_blank" rel="noopener noreferrer">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-small">
+            </a>
+            <a href="https://aromanolaindiancuisine.com/" target="_blank" rel="noopener noreferrer">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-small">
+            </a>
+            <a href="https://destinationindiala.com/" target="_blank" rel="noopener noreferrer">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-small">
+            </a>
+        </div>
+    </section>
 </main>
 
 <?php wp_footer(); ?>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -149,15 +149,12 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         <div class="vendors-grid">
             <div class="vendor-item">
                 <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-new">
-                <p class="vendor-name">Indian Delight, MS</p>
             </div>
             <div class="vendor-item">
                 <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-new">
-                <p class="vendor-name">Aroma, NOLA</p>
             </div>
             <div class="vendor-item">
                 <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-new">
-                <p class="vendor-name">Destination India, Lafayette</p>
             </div>
         </div>
     </section>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -141,24 +141,39 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         </div>
     </section>
     
-    <!-- Footer - Three Column Layout -->
-    <section class="social-footer-grid">
-        <div class="footer-col">
-            <p class="footer-col-title">NOLAHoli.org</p>
-            <p class="footer-col-subtitle">Free Admission</p>
+    <!-- Food Vendors Section -->
+    <section class="social-vendors-new">
+        <div class="vendors-header">
+            <h3>Authentic Indian Cuisine</h3>
         </div>
-        <div class="footer-col">
-            <p class="footer-col-label">Food Vendors</p>
-            <div class="footer-vendor-logos">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="footer-vendor-logo">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="footer-vendor-logo">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="footer-vendor-logo">
+        <div class="vendors-grid">
+            <div class="vendor-item">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-new">
+                <p class="vendor-name">Indian Delight, MS</p>
+            </div>
+            <div class="vendor-item">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-new">
+                <p class="vendor-name">Aroma, NOLA</p>
+            </div>
+            <div class="vendor-item">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-new">
+                <p class="vendor-name">Destination India, Lafayette</p>
             </div>
         </div>
-        <div class="footer-col">
-            <p class="footer-col-tagline">Family Friendly</p>
-            <p class="footer-col-tagline">All Are Welcome</p>
-        </div>
+    </section>
+    
+    <!-- Info Bar -->
+    <section class="social-info-bar">
+        <span>Free Entrance</span>
+        <span class="bullet">•</span>
+        <span>Family Friendly</span>
+        <span class="bullet">•</span>
+        <span>All Are Welcome</span>
+    </section>
+    
+    <!-- Dark Footer Strip -->
+    <section class="social-dark-strip">
+        <p>Visit: <strong>NOLAHoli.org</strong></p>
     </section>
 </main>
 

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -142,21 +142,15 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
     </section>
     
     <!-- Food Vendors Section -->
-    <section class="social-vendors-new">
-        <div class="vendors-header">
-            <h3>Authentic Indian Cuisine</h3>
-        </div>
-        <div class="vendors-grid">
-            <div class="vendor-item">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-new">
-            </div>
-            <div class="vendor-item">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-new">
-            </div>
-            <div class="vendor-item">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-new">
-            </div>
-        </div>
+    <section class="social-vendors-text">
+        <p class="vendors-title">Authentic Indian Cuisine by</p>
+        <p class="vendors-names">
+            <span>Indian Delight</span>
+            <span class="separator">•</span>
+            <span>Aroma Indian Cuisine</span>
+            <span class="separator">•</span>
+            <span>Destination India</span>
+        </p>
     </section>
     
     <!-- Info Bar -->

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -27,22 +27,9 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
             <p class="presented-by">Presented by</p>
             <h2 class="sponsor-name"><?php echo esc_html($sponsor_name); ?></h2>
             <?php endif; ?>
-            <p class="hero-tagline">The Biggest</p>
-            <h1 class="hero-title-large"><span class="cursive-text">Festival of Colors</span></h1>
-            <div class="gold-ribbon">
-                <span>IN NEW ORLEANS</span>
-            </div>
+            <h1 class="hero-title-large"><span class="cursive-text">NOLA Holi Festival <?php echo esc_html($event_year); ?></span></h1>
+            <p class="hero-event-info"><?php echo esc_html($event_date); ?> @ Washington Square Park</p>
         </div>
-    </section>
-    
-    <!-- Event Title Section -->
-    <section class="social-event-title">
-        <h1 class="nola-holi-title">NOLA Holi Festival <?php echo esc_html($event_year); ?></h1>
-        <div class="event-datetime">
-            <span class="event-date-large"><?php echo esc_html($event_date); ?></span>
-            <span class="event-time-large"><?php echo esc_html($event_time); ?></span>
-        </div>
-        <p class="event-location-large">Washington Square Park, New Orleans</p>
     </section>
     
     <!-- Event Details Section -->

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -111,7 +111,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                     <h3>Parade Route</h3>
                 </div>
                 <div class="social-column-content">
-                    <div class="route-item">
+                    <div class="route-item highlight">
                         <span class="route-marker assemble">📍</span>
                         <span class="route-text">Assemble at Royal & Touro</span>
                     </div>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -141,25 +141,23 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
         </div>
     </section>
     
-    <!-- Footer with Website -->
-    <section class="social-footer">
-        <p class="website-url">NOLAHoli.org</p>
-        <p class="tagline">Free Admission • Family Friendly • All Are Welcome</p>
-    </section>
-    
-    <!-- Food Vendors - Logos Only -->
-    <section class="social-vendors-section">
-        <p class="vendors-label">Food Vendors</p>
-        <div class="vendors-logos">
-            <a href="https://www.indiandelightms.com/" target="_blank" rel="noopener noreferrer">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="vendor-logo-small">
-            </a>
-            <a href="https://aromanolaindiancuisine.com/" target="_blank" rel="noopener noreferrer">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="vendor-logo-small">
-            </a>
-            <a href="https://destinationindiala.com/" target="_blank" rel="noopener noreferrer">
-                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="vendor-logo-small">
-            </a>
+    <!-- Footer - Three Column Layout -->
+    <section class="social-footer-grid">
+        <div class="footer-col">
+            <p class="footer-col-title">NOLAHoli.org</p>
+            <p class="footer-col-subtitle">Free Admission</p>
+        </div>
+        <div class="footer-col">
+            <p class="footer-col-label">Food Vendors</p>
+            <div class="footer-vendor-logos">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Indian Delight logo.png" alt="Indian Delight" class="footer-vendor-logo">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Aroma Logo.png" alt="Aroma Indian Cuisine" class="footer-vendor-logo">
+                <img src="<?php echo get_template_directory_uri(); ?>/images/Destination India Logo.PNG" alt="Destination India" class="footer-vendor-logo">
+            </div>
+        </div>
+        <div class="footer-col">
+            <p class="footer-col-tagline">Family Friendly</p>
+            <p class="footer-col-tagline">All Are Welcome</p>
         </div>
     </section>
 </main>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -66,48 +66,36 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row-social">
                             <div class="time-col">10:00</div>
                             <div class="park-col"><strong>🎧 DJ Starts Spinning</strong><br><span class="sub">Dance with colors</span></div>
-                            <div class="parade-col empty"></div>
+                            <div class="parade-col"><span class="sub">Load up colors, head to Royal & Touro</span></div>
                         </div>
                         
                         <div class="schedule-row-social">
                             <div class="time-col">11:00</div>
                             <div class="park-col"><strong>🎵 DJ Keeps Spinning</strong><br><span class="sub">Stay & splash colors</span></div>
-                            <div class="parade-col"><strong>🎧 Parade DJ Spinning</strong><br><span class="sub">Colors at Royal & Touro</span></div>
-                        </div>
-                        
-                        <div class="schedule-row-social">
-                            <div class="time-col">11:45</div>
-                            <div class="park-col empty"></div>
-                            <div class="parade-col"><strong>📣 Parade Lineup</strong><br><span class="sub">Load up your colors</span></div>
+                            <div class="parade-col"><strong>🎧 Parade DJ Cranks Up</strong><br><span class="sub">Pre-parade party with colors</span><br><strong class="lineup-time">11:45 Parade Lineup</strong></div>
                         </div>
                         
                         <div class="schedule-row-social highlight">
                             <div class="time-col">12:00</div>
-                            <div class="park-col"><strong>🔊 DJ Ramps it Up</strong><br><span class="sub">Continue the party</span></div>
+                            <div class="park-col"><strong>🔊 DJ Jams it Up</strong><br><span class="sub">Party continues in the park</span></div>
                             <div class="parade-col"><strong>🎉 Parade Starts!</strong><br><span class="sub">Color throw on route!</span></div>
                         </div>
                         
                         <div class="schedule-row-social reunite">
                             <div class="time-col">1:00</div>
-                            <div class="park-col"><strong>🎊 Everyone Reunites!</strong></div>
-                            <div class="parade-col"><span class="sub">Parade returns</span></div>
-                        </div>
-                        
-                        <div class="schedule-row-social">
-                            <div class="time-col">1:15</div>
-                            <div class="park-col"><strong>🎭 Cultural Performances</strong></div>
-                            <div class="parade-col empty"></div>
+                            <div class="park-col"><strong>🎊 Everyone Reunites!</strong><br><span class="sub">Enjoy Cultural Performances</span></div>
+                            <div class="parade-col"><strong class="parade-return">Parade Returns</strong></div>
                         </div>
                         
                         <div class="schedule-row-social">
                             <div class="time-col">2:30</div>
-                            <div class="park-col"><strong>💃 Let's Dance!</strong><br><span class="sub">DJ cranks it up</span></div>
+                            <div class="park-col"><strong>💃 DJ Cranks It Up</strong><br><span class="sub">Dance your heart out</span></div>
                             <div class="parade-col empty"></div>
                         </div>
                         
                         <div class="schedule-row-social">
                             <div class="time-col">5:00</div>
-                            <div class="park-col"><strong>🎨 Event Ends</strong></div>
+                            <div class="park-col"><strong>🎨 See You Next Year!</strong></div>
                             <div class="parade-col empty"></div>
                         </div>
                     </div>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -59,6 +59,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <span class="time">10:00 AM</span>
                         <span class="dotted-line"></span>
                         <span class="activity">Event Opens</span>
+                        <span class="event-subtext">DJ music, colors, food & drinks!</span>
                     </div>
                     <div class="schedule-item highlight">
                         <span class="time">11:00 AM</span>

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -122,7 +122,14 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                 </div>
                 <div class="social-column-content map-content">
                     <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="Parade Route Map" class="social-map-image">
-                    <p class="route-text-inline"><strong>Route:</strong> Royal & Touro → St Philip → Chartres → Kerlerec</p>
+                    <div class="route-steps-compact">
+                        <p class="route-label">Route:</p>
+                        <p class="route-step">📍 Start at Royal & Touro</p>
+                        <p class="route-step">↓ to Esplanade</p>
+                        <p class="route-step">← Left on St Philip</p>
+                        <p class="route-step">← Left on Chartres</p>
+                        <p class="route-step">⬤ End at Chartres & Kerlerec</p>
+                    </div>
                 </div>
             </div>
             

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -66,7 +66,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                         <div class="schedule-row-social">
                             <div class="time-col">10:00</div>
                             <div class="park-col"><strong>🎧 DJ Starts Spinning</strong><br><span class="sub">Dance with colors</span></div>
-                            <div class="parade-col"><span class="sub">Load up colors, head to Royal & Touro</span></div>
+                            <div class="parade-col"><strong>&nbsp;</strong><br><span class="sub">Load up colors, head to Royal & Touro</span></div>
                         </div>
                         
                         <div class="schedule-row-social">

--- a/page-templates/template-social-share.php
+++ b/page-templates/template-social-share.php
@@ -46,50 +46,70 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
     <section class="social-details-section">
         <h2 class="social-section-title">Event Details</h2>
         
-        <div class="social-three-columns">
+        <div class="social-two-columns">
             
-            <!-- Schedule Column -->
-            <div class="social-column">
+            <!-- Schedule Column (Two-Track) -->
+            <div class="social-column wide">
                 <div class="social-column-header schedule-header-bg">
                     <span class="column-icon">🗓</span>
                     <h3>Schedule</h3>
                 </div>
                 <div class="social-column-content">
-                    <div class="schedule-item">
-                        <span class="time">10:00 AM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Event Opens</span>
-                        <span class="event-subtext">DJ music, colors, food & drinks!</span>
-                    </div>
-                    <div class="schedule-item highlight">
-                        <span class="time">11:00 AM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Parade Assembly</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">12:00 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">🎉 Parade Starts!</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">1:00 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Parade Returns</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">1:15 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Performances</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">2:30 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">DJ Set</span>
-                    </div>
-                    <div class="schedule-item">
-                        <span class="time">5:00 PM</span>
-                        <span class="dotted-line"></span>
-                        <span class="activity">Event Ends</span>
+                    <div class="dual-schedule-social">
+                        <!-- Column Headers -->
+                        <div class="schedule-row-social header-row">
+                            <div class="time-col"></div>
+                            <div class="park-col">🏞️ At the Park</div>
+                            <div class="parade-col">🎭 Parade</div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">10:00</div>
+                            <div class="park-col"><strong>🎧 DJ Starts Spinning</strong><br><span class="sub">Dance with colors</span></div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">11:00</div>
+                            <div class="park-col"><strong>🎵 DJ Keeps Spinning</strong><br><span class="sub">Stay & splash colors</span></div>
+                            <div class="parade-col"><strong>🎧 Parade DJ Spinning</strong><br><span class="sub">Colors at Royal & Touro</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">11:45</div>
+                            <div class="park-col empty"></div>
+                            <div class="parade-col"><strong>📣 Parade Lineup</strong><br><span class="sub">Load up your colors</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social highlight">
+                            <div class="time-col">12:00</div>
+                            <div class="park-col"><strong>🔊 DJ Ramps it Up</strong><br><span class="sub">Continue the party</span></div>
+                            <div class="parade-col"><strong>🎉 Parade Starts!</strong><br><span class="sub">Color throw on route!</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social reunite">
+                            <div class="time-col">1:00</div>
+                            <div class="park-col"><strong>🎊 Everyone Reunites!</strong></div>
+                            <div class="parade-col"><span class="sub">Parade returns</span></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">1:15</div>
+                            <div class="park-col"><strong>🎭 Cultural Performances</strong></div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">2:30</div>
+                            <div class="park-col"><strong>💃 Let's Dance!</strong><br><span class="sub">DJ cranks it up</span></div>
+                            <div class="parade-col empty"></div>
+                        </div>
+                        
+                        <div class="schedule-row-social">
+                            <div class="time-col">5:00</div>
+                            <div class="park-col"><strong>🎨 Event Ends</strong></div>
+                            <div class="parade-col empty"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -102,40 +122,7 @@ $sponsor_name = $presenting_sponsor ? $presenting_sponsor['name'] : '';
                 </div>
                 <div class="social-column-content map-content">
                     <img src="<?php echo get_template_directory_uri(); ?>/images/2026-parade-route.png" alt="Parade Route Map" class="social-map-image">
-                </div>
-            </div>
-            
-            <!-- Parade Route Column -->
-            <div class="social-column">
-                <div class="social-column-header route-header-bg">
-                    <span class="column-icon">🧭</span>
-                    <h3>Parade Route</h3>
-                </div>
-                <div class="social-column-content">
-                    <div class="route-item highlight">
-                        <span class="route-marker assemble">📍</span>
-                        <span class="route-text">Assemble at Royal & Touro</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker start">▶</span>
-                        <span class="route-text">Start down Royal St</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker turn">←</span>
-                        <span class="route-text">Left on St Philip</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker turn">←</span>
-                        <span class="route-text">Left on Chartres</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker straight">↓</span>
-                        <span class="route-text">Continue on Chartres</span>
-                    </div>
-                    <div class="route-item">
-                        <span class="route-marker end">⬤</span>
-                        <span class="route-text">End at Chartres & Kerlerec</span>
-                    </div>
+                    <p class="route-text-inline"><strong>Route:</strong> Royal & Touro → St Philip → Chartres → Kerlerec</p>
                 </div>
             </div>
             

--- a/style.css
+++ b/style.css
@@ -2889,24 +2889,24 @@ details[open] .check-arrow {
 }
 
 .social-hero .presented-by {
-    font-size: 1.1rem;
+    font-size: 1.2rem;
 }
 
 .social-hero .sponsor-name {
-    font-size: 2.2rem;
-    margin-bottom: 8px;
+    font-size: 2.4rem;
+    margin-bottom: 10px;
 }
 
 .social-hero .hero-title-large {
-    font-size: 3.5rem;
+    font-size: 4rem;
 }
 
 .hero-event-info {
-    font-size: 1.5rem;
-    color: white;
-    margin: 12px 0 0 0;
+    font-size: 1.7rem;
+    color: var(--mardi-gras-gold);
+    margin: 15px 0 0 0;
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-    font-weight: 500;
+    font-weight: 600;
 }
 
 /* Details Section */
@@ -3151,7 +3151,7 @@ details[open] .check-arrow {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 12px 10px;
+    padding: 8px 15px;
     text-align: center;
 }
 
@@ -3160,18 +3160,10 @@ details[open] .check-arrow {
 }
 
 .vendor-logo-new {
-    height: 50px;
+    height: 70px;
     width: auto;
-    max-width: 100px;
+    max-width: 180px;
     object-fit: contain;
-    margin-bottom: 6px;
-}
-
-.vendor-name {
-    font-size: 0.85rem;
-    color: #333;
-    margin: 0;
-    font-weight: 500;
 }
 
 /* Info Bar */

--- a/style.css
+++ b/style.css
@@ -3116,6 +3116,35 @@ details[open] .check-arrow {
     margin: 0;
 }
 
+/* Social Share Vendors Section */
+.social-vendors-section {
+    background: #f5f5f5;
+    padding: 12px 20px;
+    text-align: center;
+}
+
+.social-vendors-section .vendors-label {
+    font-size: 0.8rem;
+    color: #666;
+    margin: 0 0 8px 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.social-vendors-section .vendors-logos {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 35px;
+}
+
+.social-vendors-section .vendor-logo-small {
+    height: 45px;
+    width: auto;
+    max-width: 110px;
+    object-fit: contain;
+}
+
 @media (max-width: 768px) {
     .social-hero .hero-title-large {
         font-size: 2.2rem;

--- a/style.css
+++ b/style.css
@@ -3120,50 +3120,32 @@ details[open] .check-arrow {
     margin: 0;
 }
 
-/* Social Vendors Section - New Design */
-.social-vendors-new {
+/* Social Vendors Section - Text Only */
+.social-vendors-text {
     background: var(--white);
-    padding: 0;
-    border-top: 3px solid var(--mardi-gras-purple);
-}
-
-.vendors-header {
+    padding: 12px 20px;
     text-align: center;
-    padding: 10px 20px;
+    border-top: 3px solid var(--mardi-gras-purple);
     border-bottom: 2px solid var(--mardi-gras-purple);
 }
 
-.vendors-header h3 {
-    font-size: 1.4rem;
+.vendors-title {
+    font-size: 1rem;
+    color: #666;
+    margin: 0 0 6px 0;
+    font-style: italic;
+}
+
+.vendors-names {
+    font-size: 1.3rem;
     color: var(--mardi-gras-purple);
     margin: 0;
-    font-weight: 700;
+    font-weight: 600;
 }
 
-.vendors-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    border-bottom: 2px solid var(--mardi-gras-purple);
-}
-
-.vendor-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 8px 15px;
-    text-align: center;
-}
-
-.vendor-item:not(:last-child) {
-    border-right: 1px solid #e0e0e0;
-}
-
-.vendor-logo-new {
-    height: 70px;
-    width: auto;
-    max-width: 180px;
-    object-fit: contain;
+.vendors-names .separator {
+    margin: 0 12px;
+    color: var(--mardi-gras-gold);
 }
 
 /* Info Bar */

--- a/style.css
+++ b/style.css
@@ -3001,8 +3001,8 @@ details[open] .check-arrow {
 .schedule-item .time {
     font-weight: 700;
     color: var(--mardi-gras-purple);
-    font-size: 1rem;
-    min-width: 75px;
+    font-size: 1.1rem;
+    min-width: 80px;
     flex-shrink: 0;
 }
 
@@ -3011,8 +3011,8 @@ details[open] .check-arrow {
     height: 1px;
     background: repeating-linear-gradient(
         90deg,
-        #aaa,
-        #aaa 3px,
+        #999,
+        #999 3px,
         transparent 3px,
         transparent 8px
     );
@@ -3020,8 +3020,8 @@ details[open] .check-arrow {
 }
 
 .schedule-item .activity {
-    color: #222;
-    font-size: 1rem;
+    color: #111;
+    font-size: 1.1rem;
     font-weight: 600;
     text-align: right;
     flex-shrink: 0;
@@ -3090,8 +3090,8 @@ details[open] .check-arrow {
 }
 
 .route-text {
-    font-size: 1rem;
-    color: #222;
+    font-size: 1.1rem;
+    color: #111;
     font-weight: 600;
 }
 
@@ -3116,33 +3116,65 @@ details[open] .check-arrow {
     margin: 0;
 }
 
-/* Social Share Vendors Section */
-.social-vendors-section {
-    background: #f5f5f5;
-    padding: 12px 20px;
-    text-align: center;
+/* Social Footer - Three Column Grid */
+.social-footer-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    background: linear-gradient(135deg, #1a0533 0%, #0d0d2b 100%);
+    padding: 15px 20px;
 }
 
-.social-vendors-section .vendors-label {
-    font-size: 0.8rem;
-    color: #666;
-    margin: 0 0 8px 0;
+.footer-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 5px 10px;
+}
+
+.footer-col-title {
+    font-size: 1.5rem;
+    color: var(--mardi-gras-gold);
+    font-weight: 700;
+    margin: 0 0 3px 0;
+}
+
+.footer-col-subtitle {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 0;
+}
+
+.footer-col-label {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 0 0 6px 0;
     text-transform: uppercase;
     letter-spacing: 1px;
 }
 
-.social-vendors-section .vendors-logos {
+.footer-vendor-logos {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 35px;
+    gap: 12px;
 }
 
-.social-vendors-section .vendor-logo-small {
-    height: 45px;
+.footer-vendor-logo {
+    height: 40px;
     width: auto;
-    max-width: 110px;
+    max-width: 80px;
     object-fit: contain;
+    background: white;
+    padding: 4px 6px;
+    border-radius: 4px;
+}
+
+.footer-col-tagline {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 2px 0;
 }
 
 @media (max-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -2888,17 +2888,21 @@ details[open] .check-arrow {
     min-height: 220px;
 }
 
+.social-hero .presented-by {
+    font-size: 1.1rem;
+}
+
 .social-hero .sponsor-name {
-    font-size: 1.8rem;
+    font-size: 2.2rem;
     margin-bottom: 8px;
 }
 
 .social-hero .hero-title-large {
-    font-size: 3rem;
+    font-size: 3.5rem;
 }
 
 .hero-event-info {
-    font-size: 1.3rem;
+    font-size: 1.5rem;
     color: white;
     margin: 12px 0 0 0;
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
@@ -3116,65 +3120,92 @@ details[open] .check-arrow {
     margin: 0;
 }
 
-/* Social Footer - Three Column Grid */
-.social-footer-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    background: linear-gradient(135deg, #1a0533 0%, #0d0d2b 100%);
-    padding: 15px 20px;
+/* Social Vendors Section - New Design */
+.social-vendors-new {
+    background: var(--white);
+    padding: 0;
+    border-top: 3px solid var(--mardi-gras-purple);
 }
 
-.footer-col {
+.vendors-header {
+    text-align: center;
+    padding: 10px 20px;
+    border-bottom: 2px solid var(--mardi-gras-purple);
+}
+
+.vendors-header h3 {
+    font-size: 1.4rem;
+    color: var(--mardi-gras-purple);
+    margin: 0;
+    font-weight: 700;
+}
+
+.vendors-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    border-bottom: 2px solid var(--mardi-gras-purple);
+}
+
+.vendor-item {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    padding: 12px 10px;
     text-align: center;
-    padding: 5px 10px;
 }
 
-.footer-col-title {
-    font-size: 1.5rem;
-    color: var(--mardi-gras-gold);
-    font-weight: 700;
-    margin: 0 0 3px 0;
+.vendor-item:not(:last-child) {
+    border-right: 1px solid #e0e0e0;
 }
 
-.footer-col-subtitle {
-    font-size: 0.95rem;
-    color: rgba(255, 255, 255, 0.85);
-    margin: 0;
-}
-
-.footer-col-label {
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin: 0 0 6px 0;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-}
-
-.footer-vendor-logos {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-}
-
-.footer-vendor-logo {
-    height: 40px;
+.vendor-logo-new {
+    height: 50px;
     width: auto;
-    max-width: 80px;
+    max-width: 100px;
     object-fit: contain;
-    background: white;
-    padding: 4px 6px;
-    border-radius: 4px;
+    margin-bottom: 6px;
 }
 
-.footer-col-tagline {
-    font-size: 0.95rem;
-    color: rgba(255, 255, 255, 0.85);
-    margin: 2px 0;
+.vendor-name {
+    font-size: 0.85rem;
+    color: #333;
+    margin: 0;
+    font-weight: 500;
+}
+
+/* Info Bar */
+.social-info-bar {
+    background: var(--white);
+    padding: 10px 20px;
+    text-align: center;
+    font-size: 1.1rem;
+    color: var(--mardi-gras-purple);
+    font-weight: 600;
+    border-bottom: 2px solid var(--mardi-gras-purple);
+}
+
+.social-info-bar .bullet {
+    margin: 0 15px;
+    color: var(--mardi-gras-gold);
+}
+
+/* Dark Footer Strip */
+.social-dark-strip {
+    background: linear-gradient(135deg, #1a0533 0%, #0d0d2b 100%);
+    padding: 12px 20px;
+    text-align: center;
+}
+
+.social-dark-strip p {
+    margin: 0;
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.social-dark-strip strong {
+    color: var(--mardi-gras-gold);
+    font-size: 1.2rem;
 }
 
 @media (max-width: 768px) {

--- a/style.css
+++ b/style.css
@@ -2885,44 +2885,24 @@ details[open] .check-arrow {
 }
 
 .social-hero {
-    min-height: 350px;
+    min-height: 280px;
 }
 
-/* Event Title Section */
-.social-event-title {
-    background: linear-gradient(135deg, var(--mardi-gras-purple) 0%, #4a148c 100%);
-    padding: 40px 20px;
-    text-align: center;
-}
-
-.nola-holi-title {
-    font-size: 2.8rem;
-    color: white;
-    margin: 0 0 20px 0;
-    text-transform: uppercase;
-    letter-spacing: 3px;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
-}
-
-.event-datetime {
-    display: flex;
-    justify-content: center;
-    gap: 30px;
-    flex-wrap: wrap;
+.social-hero .sponsor-name {
+    font-size: 1.8rem;
     margin-bottom: 15px;
 }
 
-.event-date-large,
-.event-time-large {
-    font-size: 1.8rem;
-    color: var(--mardi-gras-gold);
-    font-weight: 700;
+.social-hero .hero-title-large {
+    font-size: 3rem;
 }
 
-.event-location-large {
-    font-size: 1.3rem;
-    color: rgba(255, 255, 255, 0.9);
-    margin: 0;
+.hero-event-info {
+    font-size: 1.4rem;
+    color: white;
+    margin: 20px 0 0 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+    font-weight: 500;
 }
 
 /* Details Section */
@@ -3122,19 +3102,12 @@ details[open] .check-arrow {
 }
 
 @media (max-width: 768px) {
-    .nola-holi-title {
-        font-size: 2rem;
-        letter-spacing: 1px;
+    .social-hero .hero-title-large {
+        font-size: 2.2rem;
     }
     
-    .event-date-large,
-    .event-time-large {
-        font-size: 1.4rem;
-    }
-    
-    .event-datetime {
-        flex-direction: column;
-        gap: 10px;
+    .hero-event-info {
+        font-size: 1.1rem;
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -3001,8 +3001,8 @@ details[open] .check-arrow {
 .schedule-item .time {
     font-weight: 700;
     color: var(--mardi-gras-purple);
-    font-size: 0.9rem;
-    min-width: 70px;
+    font-size: 1rem;
+    min-width: 75px;
     flex-shrink: 0;
 }
 
@@ -3011,8 +3011,8 @@ details[open] .check-arrow {
     height: 1px;
     background: repeating-linear-gradient(
         90deg,
-        #ccc,
-        #ccc 3px,
+        #aaa,
+        #aaa 3px,
         transparent 3px,
         transparent 8px
     );
@@ -3020,8 +3020,9 @@ details[open] .check-arrow {
 }
 
 .schedule-item .activity {
-    color: var(--text-dark);
-    font-size: 0.9rem;
+    color: #222;
+    font-size: 1rem;
+    font-weight: 600;
     text-align: right;
     flex-shrink: 0;
 }
@@ -3042,17 +3043,24 @@ details[open] .check-arrow {
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 6px 0;
+    padding: 8px 0;
+}
+
+.route-item.highlight {
+    background: linear-gradient(90deg, rgba(255, 215, 0, 0.25) 0%, rgba(255, 215, 0, 0.1) 100%);
+    margin: 0 -15px;
+    padding: 8px 15px;
+    border-radius: 6px;
 }
 
 .route-marker {
-    width: 30px;
-    height: 30px;
+    width: 32px;
+    height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
     border-radius: 6px;
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: 700;
     flex-shrink: 0;
 }
@@ -3082,8 +3090,9 @@ details[open] .check-arrow {
 }
 
 .route-text {
-    font-size: 0.9rem;
-    color: var(--text-dark);
+    font-size: 1rem;
+    color: #222;
+    font-weight: 600;
 }
 
 /* Social Footer */

--- a/style.css
+++ b/style.css
@@ -2907,17 +2907,17 @@ details[open] .check-arrow {
 
 /* Details Section */
 .social-details-section {
-    padding: 40px 20px;
+    padding: 20px 20px 30px;
     max-width: 1200px;
     margin: 0 auto;
 }
 
 .social-section-title {
     text-align: center;
-    font-size: 2rem;
+    font-size: 1.8rem;
     color: var(--mardi-gras-purple);
-    margin: 0 0 30px 0;
-    padding-bottom: 15px;
+    margin: 0 0 20px 0;
+    padding-bottom: 10px;
     border-bottom: 3px solid var(--mardi-gras-purple);
 }
 
@@ -2976,16 +2976,15 @@ details[open] .check-arrow {
 }
 
 .social-column-content {
-    padding: 20px;
+    padding: 15px;
 }
 
 /* Schedule Items */
 .schedule-item {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 10px 0;
-    border-bottom: 1px solid #eee;
+    padding: 8px 0;
+    border-bottom: 1px solid #f0f0f0;
 }
 
 .schedule-item:last-child {
@@ -2993,22 +2992,38 @@ details[open] .check-arrow {
 }
 
 .schedule-item.highlight {
-    background: linear-gradient(90deg, rgba(255, 215, 0, 0.2) 0%, transparent 100%);
+    background: linear-gradient(90deg, rgba(255, 215, 0, 0.25) 0%, rgba(255, 215, 0, 0.1) 100%);
     margin: 0 -20px;
-    padding: 10px 20px;
+    padding: 8px 20px;
+    border-bottom: 1px solid rgba(255, 215, 0, 0.3);
 }
 
 .schedule-item .time {
     font-weight: 700;
     color: var(--mardi-gras-purple);
-    font-size: 0.95rem;
-    min-width: 80px;
+    font-size: 0.9rem;
+    min-width: 70px;
+    flex-shrink: 0;
+}
+
+.dotted-line {
+    flex: 1;
+    height: 1px;
+    background: repeating-linear-gradient(
+        90deg,
+        #ccc,
+        #ccc 3px,
+        transparent 3px,
+        transparent 8px
+    );
+    margin: 0 10px;
 }
 
 .schedule-item .activity {
     color: var(--text-dark);
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     text-align: right;
+    flex-shrink: 0;
 }
 
 /* Map Content */
@@ -3026,8 +3041,8 @@ details[open] .check-arrow {
 .route-item {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 8px 0;
+    gap: 10px;
+    padding: 6px 0;
 }
 
 .route-marker {
@@ -3067,36 +3082,27 @@ details[open] .check-arrow {
 }
 
 .route-text {
-    font-size: 0.95rem;
-    color: var(--text-dark);
-}
-
-.route-note-social {
-    margin-top: 15px;
-    padding: 12px;
-    background: #FFF8E1;
-    border-radius: 8px;
     font-size: 0.9rem;
-    border-left: 4px solid var(--mardi-gras-gold);
+    color: var(--text-dark);
 }
 
 /* Social Footer */
 .social-footer {
     background: linear-gradient(135deg, #1a0533 0%, #0d0d2b 100%);
-    padding: 30px 20px;
+    padding: 20px 20px;
     text-align: center;
 }
 
 .website-url {
-    font-size: 2rem;
+    font-size: 1.8rem;
     color: var(--mardi-gras-gold);
     font-weight: 700;
-    margin: 0 0 10px 0;
+    margin: 0 0 5px 0;
     letter-spacing: 2px;
 }
 
 .social-footer .tagline {
-    font-size: 1.1rem;
+    font-size: 1rem;
     color: rgba(255, 255, 255, 0.8);
     margin: 0;
 }

--- a/style.css
+++ b/style.css
@@ -2876,6 +2876,268 @@ details[open] .check-arrow {
     line-height: 1.5;
 }
 
+/* ===========================
+   Social Share Page
+   =========================== */
+
+.social-share-page {
+    background: var(--white);
+}
+
+.social-hero {
+    min-height: 350px;
+}
+
+/* Event Title Section */
+.social-event-title {
+    background: linear-gradient(135deg, var(--mardi-gras-purple) 0%, #4a148c 100%);
+    padding: 40px 20px;
+    text-align: center;
+}
+
+.nola-holi-title {
+    font-size: 2.8rem;
+    color: white;
+    margin: 0 0 20px 0;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.event-datetime {
+    display: flex;
+    justify-content: center;
+    gap: 30px;
+    flex-wrap: wrap;
+    margin-bottom: 15px;
+}
+
+.event-date-large,
+.event-time-large {
+    font-size: 1.8rem;
+    color: var(--mardi-gras-gold);
+    font-weight: 700;
+}
+
+.event-location-large {
+    font-size: 1.3rem;
+    color: rgba(255, 255, 255, 0.9);
+    margin: 0;
+}
+
+/* Details Section */
+.social-details-section {
+    padding: 40px 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.social-section-title {
+    text-align: center;
+    font-size: 2rem;
+    color: var(--mardi-gras-purple);
+    margin: 0 0 30px 0;
+    padding-bottom: 15px;
+    border-bottom: 3px solid var(--mardi-gras-purple);
+}
+
+.social-three-columns {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 25px;
+}
+
+@media (max-width: 900px) {
+    .social-three-columns {
+        grid-template-columns: 1fr;
+        max-width: 500px;
+        margin: 0 auto;
+    }
+}
+
+.social-column {
+    background: var(--white);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.social-column-header {
+    padding: 15px 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.social-column-header h3 {
+    margin: 0;
+    color: white;
+    font-size: 1.3rem;
+}
+
+.column-icon {
+    font-size: 1.5rem;
+}
+
+.schedule-header-bg {
+    background: linear-gradient(135deg, var(--mardi-gras-purple) 0%, #7b1fa2 100%);
+}
+
+.map-header-bg {
+    background: linear-gradient(135deg, var(--mardi-gras-green) 0%, #2e7d32 100%);
+}
+
+.route-header-bg {
+    background: linear-gradient(135deg, var(--mardi-gras-gold) 0%, #f9a825 100%);
+}
+
+.route-header-bg h3 {
+    color: var(--text-dark);
+}
+
+.social-column-content {
+    padding: 20px;
+}
+
+/* Schedule Items */
+.schedule-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid #eee;
+}
+
+.schedule-item:last-child {
+    border-bottom: none;
+}
+
+.schedule-item.highlight {
+    background: linear-gradient(90deg, rgba(255, 215, 0, 0.2) 0%, transparent 100%);
+    margin: 0 -20px;
+    padding: 10px 20px;
+}
+
+.schedule-item .time {
+    font-weight: 700;
+    color: var(--mardi-gras-purple);
+    font-size: 0.95rem;
+    min-width: 80px;
+}
+
+.schedule-item .activity {
+    color: var(--text-dark);
+    font-size: 0.95rem;
+    text-align: right;
+}
+
+/* Map Content */
+.map-content {
+    padding: 10px;
+}
+
+.social-map-image {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
+/* Route Items */
+.route-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 0;
+}
+
+.route-marker {
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.route-marker.assemble {
+    background: #E3F2FD;
+}
+
+.route-marker.start {
+    background: var(--mardi-gras-green);
+    color: white;
+}
+
+.route-marker.turn {
+    background: var(--mardi-gras-purple);
+    color: white;
+}
+
+.route-marker.straight {
+    background: var(--mardi-gras-purple);
+    color: white;
+}
+
+.route-marker.end {
+    background: var(--mardi-gras-gold);
+    color: var(--text-dark);
+}
+
+.route-text {
+    font-size: 0.95rem;
+    color: var(--text-dark);
+}
+
+.route-note-social {
+    margin-top: 15px;
+    padding: 12px;
+    background: #FFF8E1;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    border-left: 4px solid var(--mardi-gras-gold);
+}
+
+/* Social Footer */
+.social-footer {
+    background: linear-gradient(135deg, #1a0533 0%, #0d0d2b 100%);
+    padding: 30px 20px;
+    text-align: center;
+}
+
+.website-url {
+    font-size: 2rem;
+    color: var(--mardi-gras-gold);
+    font-weight: 700;
+    margin: 0 0 10px 0;
+    letter-spacing: 2px;
+}
+
+.social-footer .tagline {
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.8);
+    margin: 0;
+}
+
+@media (max-width: 768px) {
+    .nola-holi-title {
+        font-size: 2rem;
+        letter-spacing: 1px;
+    }
+    
+    .event-date-large,
+    .event-time-large {
+        font-size: 1.4rem;
+    }
+    
+    .event-datetime {
+        flex-direction: column;
+        gap: 10px;
+    }
+}
+
 .quick-info-card.featured {
     background: linear-gradient(135deg, var(--mardi-gras-green) 0%, #4CAF50 100%);
     color: white;

--- a/style.css
+++ b/style.css
@@ -2885,12 +2885,12 @@ details[open] .check-arrow {
 }
 
 .social-hero {
-    min-height: 280px;
+    min-height: 220px;
 }
 
 .social-hero .sponsor-name {
     font-size: 1.8rem;
-    margin-bottom: 15px;
+    margin-bottom: 8px;
 }
 
 .social-hero .hero-title-large {
@@ -2898,16 +2898,16 @@ details[open] .check-arrow {
 }
 
 .hero-event-info {
-    font-size: 1.4rem;
+    font-size: 1.3rem;
     color: white;
-    margin: 20px 0 0 0;
+    margin: 12px 0 0 0;
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
     font-weight: 500;
 }
 
 /* Details Section */
 .social-details-section {
-    padding: 20px 20px 30px;
+    padding: 15px 20px 20px;
     max-width: 1200px;
     margin: 0 auto;
 }
@@ -2916,8 +2916,8 @@ details[open] .check-arrow {
     text-align: center;
     font-size: 1.8rem;
     color: var(--mardi-gras-purple);
-    margin: 0 0 20px 0;
-    padding-bottom: 10px;
+    margin: 0 0 15px 0;
+    padding-bottom: 8px;
     border-bottom: 3px solid var(--mardi-gras-purple);
 }
 
@@ -3098,7 +3098,7 @@ details[open] .check-arrow {
 /* Social Footer */
 .social-footer {
     background: linear-gradient(135deg, #1a0533 0%, #0d0d2b 100%);
-    padding: 20px 20px;
+    padding: 15px 20px;
     text-align: center;
 }
 

--- a/style.css
+++ b/style.css
@@ -2987,6 +2987,7 @@ details[open] .check-arrow {
 .schedule-item {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     padding: 8px 0;
     border-bottom: 1px solid #f0f0f0;
 }
@@ -3029,6 +3030,15 @@ details[open] .check-arrow {
     font-weight: 600;
     text-align: right;
     flex-shrink: 0;
+}
+
+.schedule-item .event-subtext {
+    width: 100%;
+    font-size: 0.85rem;
+    color: #666;
+    font-style: italic;
+    text-align: right;
+    padding-top: 2px;
 }
 
 /* Map Content */

--- a/style.css
+++ b/style.css
@@ -2562,6 +2562,142 @@ details[open] .check-arrow {
     }
 }
 
+/* New Two-Column Event Day Grid (Schedule + Map) */
+.event-day-grid-new {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 35px;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+@media (max-width: 900px) {
+    .event-day-grid-new {
+        grid-template-columns: 1fr;
+        gap: 30px;
+    }
+}
+
+/* Dual Schedule (Park + Parade columns) */
+.dual-schedule {
+    background: var(--white);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+}
+
+.schedule-row {
+    display: grid;
+    grid-template-columns: 80px 1fr 1fr;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.schedule-row:last-child {
+    border-bottom: none;
+}
+
+.schedule-row.header-row {
+    background: linear-gradient(135deg, var(--mardi-gras-purple) 0%, #5a2d82 100%);
+    color: white;
+    font-weight: 700;
+}
+
+.schedule-row.header-row .time-col {
+    background: transparent;
+}
+
+.schedule-row.header-row .park-col,
+.schedule-row.header-row .parade-col {
+    padding: 10px 12px;
+    font-size: 0.95rem;
+}
+
+.schedule-row.highlight {
+    background: linear-gradient(90deg, rgba(255, 215, 0, 0.2) 0%, rgba(255, 215, 0, 0.1) 100%);
+}
+
+.schedule-row.reunite {
+    background: linear-gradient(90deg, rgba(46, 204, 64, 0.15) 0%, rgba(46, 204, 64, 0.05) 100%);
+}
+
+.schedule-row.last {
+    background: linear-gradient(90deg, rgba(46, 204, 64, 0.2) 0%, rgba(46, 204, 64, 0.1) 100%);
+}
+
+.time-col {
+    background: var(--mardi-gras-purple);
+    color: white;
+    font-weight: 700;
+    font-size: 0.85rem;
+    padding: 12px 8px;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.park-col,
+.parade-col {
+    padding: 10px 12px;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    border-left: 1px solid #f0f0f0;
+}
+
+.park-col strong,
+.parade-col strong {
+    color: var(--text-dark);
+    display: block;
+}
+
+.park-col .sub,
+.parade-col .sub {
+    color: #666;
+    font-size: 0.8rem;
+    font-style: italic;
+}
+
+.park-col.empty,
+.parade-col.empty {
+    background: #fafafa;
+}
+
+.col-icon {
+    margin-right: 5px;
+}
+
+/* Route text below map */
+.route-text {
+    padding: 15px;
+    background: var(--off-white);
+    border-top: 1px solid #eee;
+    font-size: 0.95rem;
+    color: var(--text-dark);
+    text-align: center;
+}
+
+@media (max-width: 600px) {
+    .schedule-row {
+        grid-template-columns: 60px 1fr 1fr;
+    }
+    
+    .time-col {
+        font-size: 0.75rem;
+        padding: 10px 5px;
+    }
+    
+    .park-col,
+    .parade-col {
+        font-size: 0.8rem;
+        padding: 8px 10px;
+    }
+    
+    .park-col .sub,
+    .parade-col .sub {
+        font-size: 0.7rem;
+    }
+}
+
 /* Schedule Section */
 .event-schedule {
     background: var(--white);
@@ -2937,6 +3073,111 @@ details[open] .check-arrow {
         max-width: 500px;
         margin: 0 auto;
     }
+}
+
+/* Social Two-Column Layout (Schedule + Map) */
+.social-two-columns {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 20px;
+}
+
+@media (max-width: 800px) {
+    .social-two-columns {
+        grid-template-columns: 1fr;
+    }
+}
+
+.social-column.wide {
+    min-width: 0;
+}
+
+/* Social Dual Schedule */
+.dual-schedule-social {
+    background: var(--white);
+}
+
+.schedule-row-social {
+    display: grid;
+    grid-template-columns: 55px 1fr 1fr;
+    border-bottom: 1px solid #eee;
+}
+
+.schedule-row-social:last-child {
+    border-bottom: none;
+}
+
+.schedule-row-social.header-row {
+    background: linear-gradient(135deg, var(--mardi-gras-purple) 0%, #5a2d82 100%);
+    color: white;
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+
+.schedule-row-social.header-row .time-col {
+    background: transparent;
+}
+
+.schedule-row-social.header-row .park-col,
+.schedule-row-social.header-row .parade-col {
+    padding: 8px 10px;
+}
+
+.schedule-row-social .time-col {
+    background: var(--mardi-gras-purple);
+    color: white;
+    font-weight: 700;
+    font-size: 0.8rem;
+    padding: 8px 5px;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.schedule-row-social .park-col,
+.schedule-row-social .parade-col {
+    padding: 8px 10px;
+    font-size: 0.85rem;
+    line-height: 1.3;
+    border-left: 1px solid #eee;
+}
+
+.schedule-row-social .park-col strong,
+.schedule-row-social .parade-col strong {
+    color: #111;
+    display: block;
+    font-size: 0.85rem;
+}
+
+.schedule-row-social .sub {
+    color: #555;
+    font-size: 0.75rem;
+    font-style: italic;
+}
+
+.schedule-row-social.highlight {
+    background: linear-gradient(90deg, rgba(255, 215, 0, 0.25) 0%, rgba(255, 215, 0, 0.1) 100%);
+}
+
+.schedule-row-social.reunite {
+    background: linear-gradient(90deg, rgba(46, 204, 64, 0.2) 0%, rgba(46, 204, 64, 0.05) 100%);
+}
+
+.schedule-row-social .park-col.empty,
+.schedule-row-social .parade-col.empty {
+    background: #f9f9f9;
+}
+
+/* Route text inline below map */
+.route-text-inline {
+    margin: 10px 0 0 0;
+    padding: 10px;
+    background: #f5f5f5;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    color: #333;
+    text-align: center;
 }
 
 .social-column {

--- a/style.css
+++ b/style.css
@@ -2646,15 +2646,31 @@ details[open] .check-arrow {
 
 .park-col strong,
 .parade-col strong {
-    color: var(--text-dark);
+    color: var(--mardi-gras-purple);
     display: block;
+    font-weight: 700;
 }
 
 .park-col .sub,
 .parade-col .sub {
-    color: #666;
+    color: #333;
     font-size: 0.8rem;
-    font-style: italic;
+    font-weight: 600;
+}
+
+/* Lineup time embedded in 11:00 row */
+.lineup-time {
+    display: block;
+    margin-top: 5px;
+    color: var(--mardi-gras-purple);
+    font-size: 0.9rem;
+    font-weight: 700;
+}
+
+/* Parade returns in purple */
+.parade-return {
+    color: var(--mardi-gras-purple);
+    font-weight: 700;
 }
 
 .park-col.empty,
@@ -3169,6 +3185,21 @@ details[open] .check-arrow {
 .schedule-row-social .park-col.empty,
 .schedule-row-social .parade-col.empty {
     background: #f9f9f9;
+}
+
+/* Lineup time embedded in 11:00 row */
+.schedule-row-social .lineup-time {
+    display: block;
+    margin-top: 4px;
+    color: var(--mardi-gras-purple);
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+/* Parade returns in purple */
+.schedule-row-social .parade-return {
+    color: var(--mardi-gras-purple);
+    font-weight: 700;
 }
 
 /* Route text inline below map */

--- a/style.css
+++ b/style.css
@@ -3145,15 +3145,17 @@ details[open] .check-arrow {
 
 .schedule-row-social .park-col strong,
 .schedule-row-social .parade-col strong {
-    color: #111;
+    color: var(--mardi-gras-purple);
     display: block;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
+    font-weight: 700;
 }
 
 .schedule-row-social .sub {
-    color: #555;
-    font-size: 0.75rem;
-    font-style: italic;
+    color: #111;
+    font-size: 0.8rem;
+    font-weight: 600;
+    font-style: normal;
 }
 
 .schedule-row-social.highlight {
@@ -3178,6 +3180,29 @@ details[open] .check-arrow {
     font-size: 0.85rem;
     color: #333;
     text-align: center;
+}
+
+/* Compact route steps below map */
+.route-steps-compact {
+    margin-top: 10px;
+    padding: 12px;
+    background: #f8f8f8;
+    border-radius: 8px;
+}
+
+.route-steps-compact .route-label {
+    font-weight: 700;
+    color: var(--mardi-gras-purple);
+    font-size: 0.9rem;
+    margin: 0 0 6px 0;
+}
+
+.route-steps-compact .route-step {
+    margin: 3px 0;
+    padding-left: 5px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #222;
 }
 
 .social-column {


### PR DESCRIPTION
## Changes

### Two-Column Schedule (Park vs Parade)
- Shows parallel activities at the park and parade locations
- Clear visual distinction between what's happening at each location
- DJ + Colors messaging throughout

### Schedule Updates
- 10:00: DJ Starts Spinning / Load up colors
- 11:00: DJ Keeps Spinning / Parade DJ Cranks Up (includes 11:45 Parade Lineup)
- 12:00: DJ Jams it Up / Parade Starts!
- 1:00: Everyone Reunites! / Parade Returns
- 2:30: DJ Cranks It Up
- 5:00: See You Next Year!

### Route Display
- Compact route steps below the parade map
- Route: Royal & Touro â†’ Esplanade â†’ St Philip â†’ Chartres â†’ Kerlerec

### Readability Improvements
- Purple/bold headings
- Black/bold subtext (no more light gray)
- Better visual hierarchy

### Social Share Templates
- Updated Facebook and Instagram templates with same layout
- Food vendors displayed as text names
- Consistent styling across all pages